### PR TITLE
context.runtimeType

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,3 +63,54 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 }
+
+class App extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Surf',
+      home: MyFirstWidget()
+    );
+  }
+}
+
+class MyFirstWidget extends StatelessWidget {
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    print(++counter);
+    return Container(
+      child: Center( 
+          child: Text('Hello!'),
+      ),
+    );
+  }
+
+  getContextRunType() {
+    //return context.runtimeType;
+  }
+}
+
+class MySecondWidget extends StatefulWidget {
+  @override
+  createState() => new MySecondWidgetState();
+}
+
+class MySecondWidgetState extends State<MySecondWidget> {
+  int counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    print(++counter);
+    return Container(
+      child: Center( 
+          child: Text('Hello!', textDirection: TextDirection.ltr),
+      ),
+    );
+  }
+
+  getContextRunType() {
+    return context.runtimeType;
+  }
+} 


### PR DESCRIPTION
1) Проект не запускается, в консоли выводится ошибка: Target file "lib/main.dart" not found. Точкой входа по умолчанию является функция main() в файле main.dart.
4) согласно документации: On Android the titles appear above the task manager's app snapshots which are displayed when the user presses the "recent apps" button. On iOS this value cannot be used.
P.S. Запустил эмулятор, но в недавно запущенных приложениях title не обнаружил, отображаются только экраны  открытых приложений.
5) При попытке вернуть context.runtimeType в Stateless виджете получаю ошибку. StatelessWidget не предоставляет доступ к context вне метода build().
6) Вызов context.runtimeType не вызвал ошибку, так как у Stateful виджета есть доступ к context.