### PR TITLE
13-2-MultiProvider

### DIFF
--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -2,7 +2,11 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:places/data/api/api_constants.dart';
 import 'package:places/data/exceptions/network_exception.dart';
-import 'package:places/main.dart';
+import 'package:places/data/interactor/place_interactor.dart';
+import 'package:places/data/interactor/search_interactor.dart';
+
+final placeInteractor = PlaceInteractor();
+final searchInteractor = SearchInteractor();
 
 class ApiClient {
   final _baseOptions = BaseOptions(

--- a/lib/data/interactor/place_interactor.dart
+++ b/lib/data/interactor/place_interactor.dart
@@ -54,6 +54,7 @@ class PlaceInteractor extends ChangeNotifier {
 
   Stream<bool> isFavoritePlace(Place place) async* {
     yield _placeRepository.isFavoritePlace(place);
+    notifyListeners();
   }
 
   Future<void> addToFavorites(Place place) async {

--- a/lib/data/interactor/place_interactor.dart
+++ b/lib/data/interactor/place_interactor.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:places/data/repository/place_repository.dart';
 import 'package:places/domain/place.dart';
 
-class PlaceInteractor {
-  final PlaceRepository _placeRepository;
+class PlaceInteractor extends ChangeNotifier {
+  final PlaceRepository _placeRepository = PlaceRepository();
   final StreamController<List<Place>> _listPlacesController =
       StreamController<List<Place>>.broadcast();
 
@@ -13,7 +14,7 @@ class PlaceInteractor {
     return _listPlacesController.stream;
   }
 
-  PlaceInteractor(this._placeRepository);
+  PlaceInteractor();
 
   void addErrorToPlacesController(Object error) {
     _listPlacesController.addError(error);
@@ -57,10 +58,14 @@ class PlaceInteractor {
 
   Future<void> addToFavorites(Place place) async {
     await _placeRepository.addToFavorites(place);
+    notifyListeners();
+    debugPrint('add');
   }
 
   Future<void> removeFromFavorites(Place place) async {
     await _placeRepository.removeFromFavorites(place);
+    notifyListeners();
+    debugPrint('remove');
   }
 
   // Methods for working with visited places

--- a/lib/data/interactor/place_interactor.dart
+++ b/lib/data/interactor/place_interactor.dart
@@ -54,19 +54,16 @@ class PlaceInteractor extends ChangeNotifier {
 
   Stream<bool> isFavoritePlace(Place place) async* {
     yield _placeRepository.isFavoritePlace(place);
-    notifyListeners();
   }
 
   Future<void> addToFavorites(Place place) async {
     await _placeRepository.addToFavorites(place);
     notifyListeners();
-    debugPrint('add');
   }
 
   Future<void> removeFromFavorites(Place place) async {
     await _placeRepository.removeFromFavorites(place);
     notifyListeners();
-    debugPrint('remove');
   }
 
   // Methods for working with visited places

--- a/lib/data/interactor/search_interactor.dart
+++ b/lib/data/interactor/search_interactor.dart
@@ -7,14 +7,14 @@ import 'package:places/domain/settings_filter.dart';
 import 'package:places/ui/screens/res/constants.dart' as Constants;
 
 class SearchInteractor {
-  final SearchRepository _searchRepository;
+  final _searchRepository = SearchRepository();
   final StreamController<List<Place>> _listFiltredController =
       StreamController<List<Place>>.broadcast();
   final StreamController<List<String>> _listCategoriesController =
       StreamController<List<String>>.broadcast();
   RangeValues distanceRangeValue = Constants.defaultDistanceRange;
 
-  SearchInteractor(this._searchRepository);
+  SearchInteractor();
 
   Stream<List<Place>> getFiltredPlacesStream(
     SettingsFilter? settingsFilter,

--- a/lib/data/repository/place_repository.dart
+++ b/lib/data/repository/place_repository.dart
@@ -1,15 +1,17 @@
 import 'package:dio/dio.dart';
+import 'package:places/data/api/api_client.dart';
 import 'package:places/data/api/api_constants.dart';
 import 'package:places/data/model/place_dto.dart';
 import 'package:places/data/repository/mapper/place_mapper.dart';
 import 'package:places/domain/place.dart';
 
+final api = ApiClient().client;
+
 class PlaceRepository {
   final List<Place> favoritePlaces = [];
   final List<Place> visitPlaces = [];
-  final Dio api;
 
-  PlaceRepository(this.api);
+  PlaceRepository();
 
   Future<List<Place>> getPlaces() async {
     final response = await api.get<List<dynamic>>(ApiConstants.placeUrl);

--- a/lib/data/repository/search_repository.dart
+++ b/lib/data/repository/search_repository.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:places/data/api/api_client.dart';
 import 'package:places/data/api/api_constants.dart';
@@ -10,9 +9,9 @@ import 'package:places/domain/place.dart';
 import 'package:places/domain/settings_filter.dart';
 
 class SearchRepository {
-  final Dio api;
+  final api = ApiClient().client;
 
-  SearchRepository(this.api);
+  SearchRepository();
 
   Future<List<Place>> getFiltredPlaces(SettingsFilter? settingsFilter) async {
     final data = settingsFilter!.toMap();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,23 @@
 import 'package:flutter/material.dart';
-import 'package:places/data/api/api_client.dart';
 import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/data/interactor/search_interactor.dart';
 import 'package:places/data/interactor/settings_interactor.dart';
-import 'package:places/data/repository/place_repository.dart';
-import 'package:places/data/repository/search_repository.dart';
 import 'package:places/ui/screens/splash_screen.dart';
-
-final settings = SettingsInteractor();
-final api = ApiClient().client;
-
-final _searchRepository = SearchRepository(api);
-final _placeRepository = PlaceRepository(api);
-final placeInteractor = PlaceInteractor(_placeRepository);
-final searchInteractor = SearchInteractor(_searchRepository);
+import 'package:provider/provider.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<PlaceInteractor>.value(value: PlaceInteractor()),
+        Provider<SearchInteractor>.value(value: SearchInteractor()),
+        ChangeNotifierProvider<SettingsInteractor>.value(
+          value: SettingsInteractor(),
+        ),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatefulWidget {
@@ -28,22 +29,11 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   @override
-  void initState() {
-    settings.addListener(() => setState(() {}));
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    settings.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final _theme = Provider.of<SettingsInteractor>(context).getTheme;
     return MaterialApp(
       title: 'Sights',
-      theme: settings.getTheme,
+      theme: _theme,
       home: const SplashScreen(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,10 +9,14 @@ void main() {
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider<PlaceInteractor>.value(value: PlaceInteractor()),
-        Provider<SearchInteractor>.value(value: SearchInteractor()),
-        ChangeNotifierProvider<SettingsInteractor>.value(
-          value: SettingsInteractor(),
+        ChangeNotifierProvider<PlaceInteractor>(
+          create: (_) => PlaceInteractor(),
+        ),
+        Provider<SearchInteractor>(
+          create: (_) => SearchInteractor(),
+        ),
+        ChangeNotifierProvider<SettingsInteractor>(
+          create: (_) => SettingsInteractor(),
         ),
       ],
       child: const MyApp(),

--- a/lib/ui/screens/add_sight_screen.dart
+++ b/lib/ui/screens/add_sight_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/domain/place.dart';
 import 'package:places/main.dart';
 import 'package:places/mocks.dart';
@@ -9,6 +10,7 @@ import 'package:places/ui/screens/res/icons.dart';
 import 'package:places/ui/screens/sight_category_screen.dart';
 import 'package:places/ui/widgets/add_sight_screen/gallery/sight_gallery.dart';
 import 'package:places/ui/widgets/add_sight_screen/new_sight_app_bar.dart';
+import 'package:provider/provider.dart';
 
 class AddSightScreen extends StatefulWidget {
   const AddSightScreen({Key? key}) : super(key: key);
@@ -575,10 +577,11 @@ class _CreateSightButton extends StatefulWidget {
 class _CreateSightButtonState extends State<_CreateSightButton> {
   @override
   Widget build(BuildContext context) {
+    final _placeInteractor = context.read<PlaceInteractor>();
     return ElevatedButton(
       onPressed: () {
         if (widget.formKey.currentState!.validate() && widget.enable) {
-          placeInteractor.addNewPlace(
+          _placeInteractor.addNewPlace(
             Place(
               id: 99999,
               name: widget.controllerName.text,

--- a/lib/ui/screens/add_sight_screen.dart
+++ b/lib/ui/screens/add_sight_screen.dart
@@ -575,9 +575,16 @@ class _CreateSightButton extends StatefulWidget {
 }
 
 class _CreateSightButtonState extends State<_CreateSightButton> {
+  late PlaceInteractor _placeInteractor;
+
+  @override
+  void initState() {
+    super.initState();
+    _placeInteractor = context.read<PlaceInteractor>();
+  }
+
   @override
   Widget build(BuildContext context) {
-    final _placeInteractor = context.read<PlaceInteractor>();
     return ElevatedButton(
       onPressed: () {
         if (widget.formKey.currentState!.validate() && widget.enable) {

--- a/lib/ui/screens/filters_screen.dart
+++ b/lib/ui/screens/filters_screen.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/data/interactor/search_interactor.dart';
 import 'package:places/domain/place.dart';
 import 'package:places/domain/settings_filter.dart';
-import 'package:places/main.dart';
 import 'package:places/ui/screens/res/colors.dart';
 import 'package:places/ui/screens/res/constants.dart' as Constants;
 import 'package:places/ui/screens/res/icons.dart';
 import 'package:places/ui/widgets/network_exception.dart';
+import 'package:provider/provider.dart';
 
 List<String> selectFilters = [];
 
@@ -23,9 +24,16 @@ class FiltersScreen extends StatefulWidget {
 }
 
 class _FiltersScreenState extends State<FiltersScreen> {
+  late SearchInteractor searchInteractor;
   List<Place> filteredPlaces = [];
-  int countPlaces = 0;
   Map<String, bool> filters = {};
+  int countPlaces = 0;
+
+  @override
+  void initState() {
+    searchInteractor = Provider.of<SearchInteractor>(context);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -213,6 +221,13 @@ class _ShowButton extends StatefulWidget {
 }
 
 class __ShowButtonState extends State<_ShowButton> {
+  late SearchInteractor _searchInteractor;
+  @override
+  void initState() {
+    _searchInteractor = Provider.of<SearchInteractor>(context);
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     var countPlaces = 0;
@@ -225,7 +240,7 @@ class __ShowButtonState extends State<_ShowButton> {
 
     if (settingsFilter.typeFilter!.isNotEmpty) {
       final listPlaces =
-          searchInteractor.getFiltredPlacesStream(settingsFilter);
+          _searchInteractor.getFiltredPlacesStream(settingsFilter);
       return StreamBuilder<List<Place>>(
         stream: listPlaces,
         builder: (context, snapshot) {
@@ -335,8 +350,6 @@ class _FiltersCategory extends StatefulWidget {
 }
 
 class _FiltersCategoryState extends State<_FiltersCategory> {
-  final Future<List<String>> categoriesList = searchInteractor.getCategories();
-
   @override
   Widget build(BuildContext context) {
     final displayHeight = MediaQuery.of(context).size.height;

--- a/lib/ui/screens/filters_screen.dart
+++ b/lib/ui/screens/filters_screen.dart
@@ -239,10 +239,8 @@ class __ShowButtonState extends State<_ShowButton> {
     );
 
     if (settingsFilter.typeFilter!.isNotEmpty) {
-      final listPlaces =
-          _searchInteractor.getFiltredPlacesStream(settingsFilter);
       return StreamBuilder<List<Place>>(
-        stream: listPlaces,
+        stream: _searchInteractor.getFiltredPlacesStream(settingsFilter),
         builder: (context, snapshot) {
           if (snapshot.hasData && !snapshot.hasError) {
             countPlaces = snapshot.data!.length;
@@ -355,7 +353,7 @@ class _FiltersCategoryState extends State<_FiltersCategory> {
     final displayHeight = MediaQuery.of(context).size.height;
 
     if (displayHeight > 580) {
-      if (widget.categories != null)
+      if (widget.categories != null){
         return GridView.builder(
           shrinkWrap: true,
           gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
@@ -377,6 +375,7 @@ class _FiltersCategoryState extends State<_FiltersCategory> {
             );
           },
         );
+      }
     }
 
     return SizedBox(

--- a/lib/ui/screens/main_screen.dart
+++ b/lib/ui/screens/main_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:places/ui/screens/settings_screen.dart';
-import 'package:places/ui/widgets/sight_bottom_nav_bar.dart';
 import 'package:places/ui/screens/sight_list_screen.dart';
 import 'package:places/ui/screens/sight_map_screen.dart';
 import 'package:places/ui/screens/visiting_screen.dart';
+import 'package:places/ui/widgets/sight_bottom_nav_bar.dart';
 
 class MainScreen extends StatefulWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -13,8 +13,9 @@ class MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
-  late TabController _tabController;
   int selectedTab = 0;
+  late TabController _tabController;
+  
 
   @override
   void initState() {

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_switch/flutter_switch.dart';
-import 'package:places/main.dart';
+import 'package:places/data/interactor/settings_interactor.dart';
 import 'package:places/ui/screens/onboarding_screen.dart';
 import 'package:places/ui/screens/res/colors.dart';
 import 'package:places/ui/screens/res/constants.dart' as Constants;
+import 'package:provider/provider.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({Key? key}) : super(key: key);
@@ -15,6 +16,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
+    final _settingsInteractor = Provider.of<SettingsInteractor>(context);
     return Scaffold(
       backgroundColor: Theme.of(context).accentColor,
       appBar: const _AppBarSettings(),
@@ -42,10 +44,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   borderRadius: 16.0,
                   inactiveColor: myInactiveBlack.withOpacity(0.56),
                   activeColor: myDarkGreen,
-                  value: settings.getThemeValue,
+                  value: _settingsInteractor.getThemeValue,
                   onToggle: (value) {
                     setState(() {
-                      settings.changeTheme(value);
+                      _settingsInteractor.changeTheme(value);
                     });
                   },
                 ),

--- a/lib/ui/screens/sight_details_screen.dart
+++ b/lib/ui/screens/sight_details_screen.dart
@@ -251,7 +251,7 @@ class _Description extends StatelessWidget {
   }
 }
 
-class _FunctionButtons extends StatefulWidget {
+class _FunctionButtons extends StatelessWidget {
   final Place place;
 
   const _FunctionButtons({
@@ -260,20 +260,8 @@ class _FunctionButtons extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  State<_FunctionButtons> createState() => _FunctionButtonsState();
-}
-
-class _FunctionButtonsState extends State<_FunctionButtons> {
-  late PlaceInteractor _favoriteIconController;
-  @override
-  void initState() {
-    super.initState();
-    _favoriteIconController = context.read<PlaceInteractor>();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    debugPrint('refresh ui');
+    final _favoriteIconController = context.watch<PlaceInteractor>();
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
@@ -310,18 +298,17 @@ class _FunctionButtonsState extends State<_FunctionButtons> {
               children: [
                 const SizedBox(width: 14),
                 StreamProvider<bool>.value(
-                  value: _favoriteIconController.isFavoritePlace(widget.place),
+                  value: _favoriteIconController.isFavoritePlace(place),
                   initialData: false,
                   child: Consumer<bool>(
-                    builder: (context, isFavorite, _) {
+                    builder: (context, isFavorite, child) {
                       return TextButton.icon(
                         onPressed: () {
                           isFavorite
                               ? _favoriteIconController
-                                  .removeFromFavorites(widget.place)
+                                  .removeFromFavorites(place)
                               : _favoriteIconController
-                                  .addToFavorites(widget.place);
-                          // setState(() {});
+                                  .addToFavorites(place);
                         },
                         icon: SvgPicture.asset(
                           isFavorite ? iconFavoriteSelected : iconFavorite,

--- a/lib/ui/screens/sight_details_screen.dart
+++ b/lib/ui/screens/sight_details_screen.dart
@@ -35,7 +35,6 @@ class _SightDetailsState extends State<SightDetails> {
 
   @override
   Widget build(BuildContext context) {
-    
     return Material(
       child: Container(
         color: Theme.of(context).accentColor,
@@ -268,12 +267,12 @@ class _FunctionButtonsState extends State<_FunctionButtons> {
   late PlaceInteractor _favoriteIconController;
   @override
   void initState() {
-    _favoriteIconController = context.read<PlaceInteractor>();
     super.initState();
+    _favoriteIconController = context.read<PlaceInteractor>();
   }
+
   @override
   Widget build(BuildContext context) {
-    debugPrint(_favoriteIconController.isFavoritePlace(widget.place).toString());
     debugPrint('refresh ui');
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -310,38 +309,33 @@ class _FunctionButtonsState extends State<_FunctionButtons> {
             child: Row(
               children: [
                 const SizedBox(width: 14),
-                StreamBuilder<bool>(
-                  stream: _favoriteIconController.isFavoritePlace(widget.place),
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return const SizedBox.shrink();
-                    }
-
-                    if (snapshot.hasData && !snapshot.hasError) {
+                StreamProvider<bool>.value(
+                  value: _favoriteIconController.isFavoritePlace(widget.place),
+                  initialData: false,
+                  child: Consumer<bool>(
+                    builder: (context, isFavorite, _) {
                       return TextButton.icon(
                         onPressed: () {
-                          snapshot.data!
+                          isFavorite
                               ? _favoriteIconController
                                   .removeFromFavorites(widget.place)
                               : _favoriteIconController
                                   .addToFavorites(widget.place);
-                          setState(() {});
+                          // setState(() {});
                         },
                         icon: SvgPicture.asset(
-                          snapshot.data! ? iconFavoriteSelected : iconFavorite,
+                          isFavorite ? iconFavoriteSelected : iconFavorite,
                           color: Theme.of(context).iconTheme.color,
                         ),
                         label: Text(
-                          snapshot.data!
+                          isFavorite
                               ? Constants.textInFavorite
                               : Constants.textToFavorite,
                           style: Theme.of(context).textTheme.bodyText1,
                         ),
                       );
-                    } else {
-                      return const Center(child: CircularProgressIndicator());
-                    }
-                  },
+                    },
+                  ),
                 ),
               ],
             ),

--- a/lib/ui/screens/sight_list_screen.dart
+++ b/lib/ui/screens/sight_list_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:places/data/interactor/place_interactor.dart';
@@ -10,25 +8,13 @@ import 'package:places/ui/widgets/list_screen/sliver_sights.dart';
 import 'package:places/ui/widgets/network_exception.dart';
 import 'package:provider/provider.dart';
 
-class SightListScreen extends StatefulWidget {
+class SightListScreen extends StatelessWidget {
   const SightListScreen({Key? key}) : super(key: key);
 
-  @override
-  SightListScreenState createState() => SightListScreenState();
-}
-
-class SightListScreenState extends State<SightListScreen> {
-  late Stream<List<Place>> places;
-  late PlaceInteractor _placeInteractor;
-
-  @override
-  void initState() {
-    _placeInteractor = context.read<PlaceInteractor>();
-    super.initState();
-  }
-
+  
   @override
   Widget build(BuildContext context) {
+    final _placeInteractor = context.watch<PlaceInteractor>();
     return Scaffold(
       backgroundColor: Theme.of(context).accentColor,
       body: Stack(

--- a/lib/ui/screens/sight_list_screen.dart
+++ b/lib/ui/screens/sight_list_screen.dart
@@ -2,12 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/domain/place.dart';
-import 'package:places/main.dart';
 import 'package:places/ui/widgets/list_screen/add_sight_button.dart';
 import 'package:places/ui/widgets/list_screen/sliver_app_bar_list.dart';
 import 'package:places/ui/widgets/list_screen/sliver_sights.dart';
 import 'package:places/ui/widgets/network_exception.dart';
+import 'package:provider/provider.dart';
 
 class SightListScreen extends StatefulWidget {
   const SightListScreen({Key? key}) : super(key: key);
@@ -21,6 +22,7 @@ class SightListScreenState extends State<SightListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final placeInteractor = context.read<PlaceInteractor>();
     return Scaffold(
       backgroundColor: Theme.of(context).accentColor,
       body: Stack(

--- a/lib/ui/screens/sight_search_screen.dart
+++ b/lib/ui/screens/sight_search_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/data/interactor/search_interactor.dart';
 import 'package:places/domain/place.dart';
 import 'package:places/domain/settings_filter.dart';
 import 'package:places/main.dart';
@@ -11,6 +12,7 @@ import 'package:places/ui/widgets/network_exception.dart';
 import 'package:places/ui/widgets/search_screen/empty_search_result.dart';
 import 'package:places/ui/widgets/search_screen/search_bar.dart';
 import 'package:places/ui/widgets/search_screen/search_result_list.dart';
+import 'package:provider/provider.dart';
 
 List<String> historyList = [];
 
@@ -28,6 +30,13 @@ class SightSearchScreen extends StatefulWidget {
 class _SightSearchScreenState extends State<SightSearchScreen> {
   final _controllerSearch = TextEditingController();
   late Stream<List<Place>>? _filteredPlaces;
+  late SearchInteractor _searchInteractor;
+
+  @override
+  void initState() {
+    _searchInteractor = Provider.of<SearchInteractor>(context);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -86,7 +95,7 @@ class _SightSearchScreenState extends State<SightSearchScreen> {
                   return const SizedBox.shrink();
                 }
 
-                _filteredPlaces = searchInteractor.getFiltredPlacesStream(
+                _filteredPlaces = _searchInteractor.getFiltredPlacesStream(
                   widget.settingsFilter ?? SettingsFilter(),
                 );
 

--- a/lib/ui/screens/splash_screen.dart
+++ b/lib/ui/screens/splash_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/ui/screens/onboarding_screen.dart';
 import 'package:places/ui/screens/res/colors.dart';
 import 'package:places/ui/screens/res/icons.dart';
-import 'package:places/ui/screens/onboarding_screen.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);
@@ -13,22 +13,6 @@ class SplashScreen extends StatefulWidget {
 
 class _SplashScreenState extends State<SplashScreen> {
   late Future<void> isInitialized;
-
-  Future<void> _navigateToNext() async {
-    return Future.delayed(
-      const Duration(seconds: 2),
-      () => {
-        Navigator.pushReplacement<void, void>(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const OnboardingScreen(),
-          ),
-        ),
-      },
-    ).then(
-      (_) => debugPrint('Переход на следующий экран'),
-    );
-  }
 
   @override
   void initState() {
@@ -59,6 +43,22 @@ class _SplashScreenState extends State<SplashScreen> {
           child: SvgPicture.asset(iconSplash, color: Colors.white),
         ),
       ),
+    );
+  }
+
+  Future<void> _navigateToNext() async {
+    return Future.delayed(
+      const Duration(seconds: 2),
+      () => {
+        Navigator.pushReplacement<void, void>(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const OnboardingScreen(),
+          ),
+        ),
+      },
+    ).then(
+      (_) => debugPrint('Переход на следующий экран'),
     );
   }
 }

--- a/lib/ui/screens/visiting_screen.dart
+++ b/lib/ui/screens/visiting_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/domain/place.dart';
-import 'package:places/main.dart';
 import 'package:places/ui/screens/res/icons.dart';
 import 'package:places/ui/widgets/visiting_screen/card/sight_visiting_portrain_widget.dart';
 import 'package:places/ui/widgets/visiting_screen/favorites_empty.dart';
 import 'package:places/ui/widgets/visiting_screen/visiting_app_bar.dart';
+import 'package:provider/provider.dart';
 
 /// Screen for displaying planned and visited places
 class VisitingScreen extends StatelessWidget {
@@ -33,20 +34,30 @@ class _FavoriteTabBarView extends StatefulWidget {
 }
 
 class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
-  final Future<List<Place>> isVisited = placeInteractor.getVisitPlaces();
-  final Future<List<Place>> notVisited = placeInteractor.getFavoritesPlaces();
+  late PlaceInteractor _placeInteractor;
+  late Future<List<Place>> _isVisited;
+  late Future<List<Place>> _notVisited;
+
+  @override
+  void initState() {
+    _placeInteractor = context.read<PlaceInteractor>();
+    _isVisited = _placeInteractor.getVisitPlaces();
+    _notVisited = _placeInteractor.getFavoritesPlaces();
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
     final isPortrait =
         MediaQuery.of(context).orientation == Orientation.portrait;
+
     return Container(
       margin: const EdgeInsets.only(top: 28),
       child: SafeArea(
         child: TabBarView(
           children: [
             FutureBuilder<List<Place>>(
-              future: notVisited,
+              future: _notVisited,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
@@ -76,7 +87,7 @@ class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
               },
             ),
             // TODO(Denis): Customize the display of items in portrait and landscape orientation for the Favorites screen.
-            // if (notVisited.isNotEmpty)
+            // if (_notVisited.isNotEmpty)
             //   isPortrait
             //       ? SightVisitingPortrainWidget(
             //           places: notVisited,
@@ -106,7 +117,7 @@ class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
             //   ),
 
             FutureBuilder<List<Place>>(
-              future: isVisited,
+              future: _isVisited,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
@@ -137,7 +148,7 @@ class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
             ),
 
             // TODO(Denis): Customize the display of items in portrait and landscape orientation for the visited places screen.
-            // if (isVisited.isNotEmpty)
+            // if (_isVisited.isNotEmpty)
             //   isPortrait
             //       ? SightVisitingPortrainWidget(
             //           places: isVisited,
@@ -194,10 +205,10 @@ class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
     setState(() {
       if (visited) {
         //isVisited.remove(place);
-        placeInteractor.removeFromVisit(place);
+        // placeInteractor.removeFromVisit(place);
       } else {
         //notVisited.remove(place);
-        placeInteractor.removeFromFavorites(place);
+        // placeInteractor.removeFromFavorites(place);
       }
     });
   }

--- a/lib/ui/screens/visiting_screen.dart
+++ b/lib/ui/screens/visiting_screen.dart
@@ -204,11 +204,9 @@ class __FavoriteTabBarViewState extends State<_FavoriteTabBarView> {
   void removePlace(Place place, bool visited) {
     setState(() {
       if (visited) {
-        //isVisited.remove(place);
-        // placeInteractor.removeFromVisit(place);
+        _placeInteractor.removeFromVisit(place);
       } else {
-        //notVisited.remove(place);
-        // placeInteractor.removeFromFavorites(place);
+        _placeInteractor.removeFromFavorites(place);
       }
     });
   }

--- a/lib/ui/widgets/list_screen/card/sight_card.dart
+++ b/lib/ui/widgets/list_screen/card/sight_card.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/domain/place.dart';
-import 'package:places/main.dart';
 import 'package:places/ui/screens/res/icons.dart';
 import 'package:places/ui/screens/sight_details_screen.dart';
+import 'package:provider/provider.dart';
 
 /// A card of an interesting place to be displayed on the main screen of the application.
 class SightCard extends StatefulWidget {
@@ -17,23 +16,9 @@ class SightCard extends StatefulWidget {
 }
 
 class _SightCardState extends State<SightCard> {
-  final StreamController<bool> _favoriteIconController =
-      StreamController<bool>.broadcast();
-
-  @override
-  void initState() {
-    _refreshFavoriteIcon(widget.place);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _favoriteIconController.close();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
+    final placeInteractor = context.read<PlaceInteractor>();
     return SizedBox(
       height: 188,
       child: Stack(
@@ -67,7 +52,7 @@ class _SightCardState extends State<SightCard> {
                   ),
                 ),
                 StreamBuilder<bool>(
-                  stream: _favoriteIconController.stream,
+                  stream: placeInteractor.isFavoritePlace(widget.place),
                   builder: (context, snapshot) {
                     if (snapshot.connectionState == ConnectionState.waiting) {
                       return const SizedBox.shrink();
@@ -80,7 +65,7 @@ class _SightCardState extends State<SightCard> {
                               ? placeInteractor
                                   .removeFromFavorites(widget.place)
                               : placeInteractor.addToFavorites(widget.place);
-                          _refreshFavoriteIcon(widget.place);
+                          setState(() {});
                         },
                         icon: SvgPicture.asset(
                           snapshot.data! ? iconFavoriteSelected : iconFavorite,
@@ -100,15 +85,11 @@ class _SightCardState extends State<SightCard> {
     );
   }
 
-  void _refreshFavoriteIcon(Place place) => _favoriteIconController.sink
-      .addStream(placeInteractor.isFavoritePlace(place));
-
   void _showSight(int id) async {
-    final place = await placeInteractor.getPlaceDetails(id: id);
     await showModalBottomSheet<Place>(
       context: context,
       builder: (_) {
-        return SightDetails(id: place.id);
+        return SightDetails(id: id);
       },
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
@@ -118,7 +99,6 @@ class _SightCardState extends State<SightCard> {
       ),
       clipBehavior: Clip.antiAliasWithSaveLayer,
     );
-    _refreshFavoriteIcon(widget.place);
   }
 }
 

--- a/lib/ui/widgets/visiting_screen/card/sight_card.dart
+++ b/lib/ui/widgets/visiting_screen/card/sight_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:places/data/interactor/place_interactor.dart';
 import 'package:places/domain/place.dart';
 import 'package:places/ui/screens/res/constants.dart' as Constants;
 import 'package:places/ui/screens/res/icons.dart';
@@ -10,6 +11,7 @@ import 'package:places/ui/screens/sight_details_screen.dart';
 import 'package:places/ui/widgets/sight_cupertino_date_picker.dart';
 import 'package:places/ui/widgets/visiting_screen/card/favorite_card_bottom.dart';
 import 'package:places/ui/widgets/visiting_screen/card/favorite_card_top.dart';
+import 'package:provider/src/provider.dart';
 
 class SightCard extends StatefulWidget {
   final GlobalKey globalKey;
@@ -31,6 +33,7 @@ class SightCard extends StatefulWidget {
 class __SightCardState extends State<SightCard> {
   @override
   Widget build(BuildContext context) {
+    final _placeInteractor = context.watch<PlaceInteractor>();
     return Material(
       borderRadius: const BorderRadius.all(Radius.circular(16)),
       child: Container(
@@ -156,12 +159,7 @@ class __SightCardState extends State<SightCard> {
                         color: Colors.white,
                       ),
                       onTap: () {
-                        setState(() {
-                          widget.removeSight(
-                            widget.place,
-                            widget.visited,
-                          );
-                        });
+                        _placeInteractor.removeFromFavorites(widget.place);
                       },
                     ),
                   ],

--- a/lib/ui/widgets/visiting_screen/card/sight_card.dart
+++ b/lib/ui/widgets/visiting_screen/card/sight_card.dart
@@ -4,7 +4,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:places/domain/place.dart';
-import 'package:places/main.dart';
 import 'package:places/ui/screens/res/constants.dart' as Constants;
 import 'package:places/ui/screens/res/icons.dart';
 import 'package:places/ui/screens/sight_details_screen.dart';
@@ -176,11 +175,10 @@ class __SightCardState extends State<SightCard> {
   }
 
   void _showSight(int id) async {
-    final place = await placeInteractor.getPlaceDetails(id: id);
     await showModalBottomSheet<Place>(
       context: context,
       builder: (_) {
-        return SightDetails(id: place.id);
+        return SightDetails(id: id);
       },
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -228,6 +228,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -270,6 +277,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  provider: ^6.0.1
   cupertino_icons: ^1.0.2
   flutter_svg: ^0.22.0
   flutter_switch: ^0.3.2


### PR DESCRIPTION
Добавил MultiProvider:
1) Для экрана настроек ChangeNotifierProvider, слушаю изменение текущей темы.
2) Для экрана поиска и фильтров Provider. Никаких изменений не слушаю, просто получаю данные из репы. 
3) Для экрана "Список интересных мест" и "Описание места" использовал ChangeNotifierProvider, так как слушаю изменение данных по карточке(добавить/убрать из избранного)
В файле lib/ui/screens/sight_details_screen.dart мне пока не удалось избавиться от setState(() {}); при нажатии на кнопку "В избранное" (На странице "Список интересных мест" аналогично).
Я правильно понимаю что использование Provider подразумевает полный отказ от метода setState(() {}) и использование Consumer/Selector? 
Или Consumer/Selector мы используем только для получения статичных данных, а в StreamBulder я так и могу оставить setState(() {}); (В файле lib/ui/screens/sight_details_screen.dart при нажатии на кнопку "В избранное")?


UPD
Во втором коммите попробовал использовать StreamBuilder с Consumer и notifyListeners, но не помогло...

UPD2
Кажется разобрался в ситуации.
Внёс правки в 4й коммит(fix).
Переделал экран описания места с StatefulWidget на StatelessWidget.
Указал watch для провайдера из конекста.
Теперь при нажатии на кноку "В избранное" место добавляется в список избранного, Consumer с кнопкой обновляется и отображается закрашенная иконка(сердечка) и надпись "В избранном". 
При закрытии экрана с описанием карточки, на экране "Список интересных мест" также отображает закрашенную иконку у карточек которые находятся в списке избранных.

